### PR TITLE
Include link to Semantic Versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,5 @@ A Discord bot created with Discord.js/Node.js, based off of my character Ceranit
 
 Various values are based off of environment variables- a template file environmentVarsTEMPLATE.env is included, and must be renamed to environmentVars.env in order to function locally.
 Hosting services, like Heroku, shouldn't require this file and have different means to set up environment variables. Required variables are visible in the template file.
+
+Follows Semantic Versioning naming principles. See https://semver.org/


### PR DESCRIPTION
Very brief update that includes the Semantic Versioning link in the README. Needed as a prerequisite to starting on version 0.1.0.